### PR TITLE
fix: use CLAUDE_PLUGIN_ROOT instead of git rev-parse in Stop hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run \"$(git rev-parse --show-toplevel)/cli/src/hooks/generate-output.ts\""
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/cli/src/hooks/generate-output.ts\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Stop hook uses `git rev-parse --show-toplevel` to locate `generate-output.ts`, but this resolves to the user's project root — not the plugin directory
- In any non-beastmode repo, the path doesn't exist, causing "Module not found" errors on every Stop event
- Replace with `${CLAUDE_PLUGIN_ROOT}` which always points to the plugin directory

Fixes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)