### PR TITLE
feat: add worktree isolation to /implement, /validate, and /release

### DIFF
--- a/plugin/skills/implement/SKILL.md
+++ b/plugin/skills/implement/SKILL.md
@@ -13,8 +13,30 @@ Load plan, dispatch subagents per task in wave order, verify completion.
 - **Session metadata is the source of truth** — the session-start hook injects a metadata block with `epic-id`, `epic-slug`, `feature-id`, `feature-name`, `feature-slug`, parent artifacts, and `output-target`. Use these values verbatim — do NOT re-derive, re-extract, or generate alternatives.
 - **Wave ordering drives sequencing** — foundation before consumers; parallel-safe waves dispatch all tasks concurrently; reviews run sequentially after all implementations complete
 - **Model escalation** — start cheap (haiku), escalate on failure (sonnet, then opus). See Reference > Model Escalation.
-- **Working directory isolation** — the CLI provides the working directory; skills don't manage worktrees; each phase commits to the feature branch at checkpoint; merge happens only at /release
+- **Working directory isolation** — `/implement` always creates a dedicated git worktree so the main repo stays clean on its current branch and multiple features can run in parallel. The worktree persists until `/release` completes the squash-merge.
 - **Subagent safety** — one agent per task; parallel-safe waves dispatch all tasks simultaneously, non-parallel-safe waves dispatch sequentially; agents commit per task via `git add <files>` + `git commit`; agents must NOT read the plan file, modify files outside their task's file list, or push/switch branches
+
+## Phase 0: Worktree Setup
+
+Before dispatching the taskplanner, ensure work happens in an isolated worktree.
+
+### 0a. Check for existing worktree
+
+```bash
+git worktree list
+```
+
+If `.claude/worktrees/<epic-slug>` already appears (interrupted prior session), use `EnterWorktree` with `path: ".claude/worktrees/<epic-slug>"` to re-enter it, then skip to Phase 1.
+
+### 0b. Create worktree (first run)
+
+```bash
+git worktree add .claude/worktrees/<epic-slug> -b feat/<epic-slug>
+```
+
+Then use `EnterWorktree` with `path: ".claude/worktrees/<epic-slug>"` to switch the session into it.
+
+All subsequent work (taskplanner, implementers, reviewers, commits, tests) runs inside this worktree. The main repo working directory is never touched.
 
 ## Phase 1: Execute
 

--- a/plugin/skills/release/SKILL.md
+++ b/plugin/skills/release/SKILL.md
@@ -16,6 +16,27 @@ No release without passing validation.
 - **Bump type auto-detected, not user-prompted** — commit message conventions determine major/minor/patch automatically
 - **Warn-and-continue for non-blocking failures** — report problems, attempt fixes, only hard-stop on critical validation failures
 
+## Phase 0: Pre-Execute
+
+### 0. Enter Worktree
+
+Release must run inside the implement worktree so that release-notes generation, the retro context walker, and the feature-branch checkpoint commit all operate on the feature branch's state. The squash-merge in Phase 3 still happens from the main repo via explicit `cd "$main_repo"`; this Phase 0 step only governs the parent skill's cwd and the cwd that subagents (notably the retro) inherit.
+
+```bash
+git worktree list
+```
+
+If already inside `.claude/worktrees/<epic-slug>` (current directory matches): skip to Phase 1.
+
+If at repo root, look for `.claude/worktrees/<epic-slug>` in the worktree list. If found, use `EnterWorktree` with `path: ".claude/worktrees/<epic-slug>"` to switch into it.
+
+If no matching worktree exists, STOP:
+
+```
+BLOCKED — no worktree found for <epic-slug>.
+Run /beastmode:implement and /beastmode:validate first, then retry.
+```
+
 ## Phase 1: Execute
 
 ### 1. Stage Uncommitted Changes
@@ -136,8 +157,6 @@ Run a context reconciliation pass across all phase artifacts before releasing.
 
 4. **Apply BEASTMODE.md Updates** — If no L0 changes proposed, skip this step. Apply L0 changes and log.
 
-> **TRANSITION BOUNDARY — Steps below operate from main repo, NOT the feature branch working directory.**
-
 ### 2. Commit to Feature Branch
 
 Before merging to main, commit all release artifacts to the feature branch:
@@ -146,6 +165,8 @@ Before merging to main, commit all release artifacts to the feature branch:
 git add -A
 git commit -m "release(<epic-name>): checkpoint"
 ```
+
+> **TRANSITION BOUNDARY — Steps below operate from main repo, NOT the feature branch working directory.**
 
 ### 3. Squash Merge to Main
 

--- a/plugin/skills/validate/SKILL.md
+++ b/plugin/skills/validate/SKILL.md
@@ -20,6 +20,25 @@ No release without passing validation.
 
 ## Phase 0: Pre-Execute
 
+### 0. Enter Worktree
+
+Validate must run inside the implement worktree where the feature code lives.
+
+```bash
+git worktree list
+```
+
+If already inside `.claude/worktrees/<epic-slug>` (current directory matches): skip to step 1.
+
+If at repo root, look for `.claude/worktrees/<epic-slug>` in the worktree list. If found, use `EnterWorktree` with `path: ".claude/worktrees/<epic-slug>"` to switch into it.
+
+If no matching worktree exists, STOP:
+
+```
+BLOCKED — no worktree found for <epic-slug>.
+Run /beastmode:implement first to create the worktree and build the feature.
+```
+
 ### 1. Check Feature Completion
 
 Scan for implementation artifacts to verify all features have been implemented:


### PR DESCRIPTION
## Summary

- `/implement` now creates a dedicated git worktree at `.claude/worktrees/<epic-slug>` before dispatching the taskplanner, enabling parallel feature implementation
- `/validate` now enters the matching worktree before running tests, so it validates the correct code even when invoked from a fresh session
- `/release` now enters the matching worktree before generating release notes and dispatching the retro context walker, so the retro reads/writes the feature branch's state and its edits land in the squash-merge
- Moved the `TRANSITION BOUNDARY` callout in `/release` Phase 3 from above Step 2 to above Step 3 — Step 2 (`Commit to Feature Branch`) still runs in the worktree; the actual transition to the main repo is at Step 3 (`Squash Merge to Main`)

Closes #564

## Changes

**`plugin/skills/implement/SKILL.md`**
- Updated working directory isolation principle to reflect skill-managed worktrees
- Added Phase 0: Worktree Setup with existing-worktree check (0a) and create-worktree (0b) steps

**`plugin/skills/validate/SKILL.md`**
- Added Step 0: Enter Worktree to Phase 0 (Pre-Execute)
- Checks `git worktree list`, enters matching worktree, or blocks if none exists

**`plugin/skills/release/SKILL.md`**
- Added Phase 0: Pre-Execute with Step 0: Enter Worktree, mirroring `/validate`'s pattern
- Without this, `/release` invoked from a fresh session at the repo root runs Phase 1 and Phase 3 Step 1 (retro context walker) from the main repo, not the worktree. The retro is dispatched as a `general-purpose` subagent that inherits the parent's cwd; with no Phase 0 entry, it reads `main`'s `.beastmode/artifacts/*` and writes to `main`'s `.beastmode/context/*` — the worktree's edits never make it through the squash-merge
- Moved the `TRANSITION BOUNDARY` callout from above Phase 3 Step 2 to above Step 3 (Step 2 is the feature-branch checkpoint commit, which still runs in the worktree; only Step 3+ navigates to the main repo via explicit `cd`)

## Context

Without these changes, running `/implement` on two features simultaneously corrupts the working tree, running `/validate` in a new session tests `main` instead of the feature branch, and the `/release` retro context walker silently writes to whichever directory the session happens to be in (often `main`, where the edits get clobbered by the subsequent squash-merge from the worktree). All three were discovered while running parallel beastmode sessions on a real project.

## Test plan

- [ ] Run `/implement` on a feature — verify worktree is created at `.claude/worktrees/<epic-slug>`
- [ ] Run `/implement` on a second feature in parallel — verify each gets its own worktree
- [ ] Run `/validate` in a fresh session — verify it finds and enters the worktree
- [ ] Run `/validate` with no worktree — verify it blocks with a clear message
- [ ] Run `/release` in a fresh session — verify it enters the worktree before the retro fires
- [ ] Run `/release` with no worktree — verify it blocks with a clear message
- [ ] Inspect the squash-merge commit — verify retro context edits (e.g., updates to `.beastmode/context/*.md`) are present on `main`