### PR TITLE
feat: add lockfile guard to /design and /plan

### DIFF
--- a/plugin/skills/design/SKILL.md
+++ b/plugin/skills/design/SKILL.md
@@ -18,6 +18,30 @@ Create PRDs through structured decision-tree interviews and collaborative dialog
 
 ## Phase 0: Pre-Execute
 
+### 0. Acquire Worktree Lock
+
+Before any work, acquire the worktree lock to prevent parallel sessions from modifying the same branch. Design and plan commit directly to the base branch (no worktree), so concurrent sessions would race on `git add -A`.
+
+```bash
+( set -C; echo "$$:design:$(date -Iseconds)" > .beastmode/.worktree-lock ) 2>/dev/null
+```
+
+If the lock file already exists (command fails), read it and STOP immediately:
+
+```bash
+cat .beastmode/.worktree-lock
+```
+
+Print:
+
+```
+BLOCKED — another beastmode session is active on this branch.
+Lock held by: <contents of lock file>
+Wait for it to finish, or remove .beastmode/.worktree-lock if the session crashed.
+```
+
+STOP. Do not proceed.
+
 ### 1. Problem-First Question
 
 Before exploring the codebase, ask the user what they are trying to solve.
@@ -170,6 +194,12 @@ Commit all work to the feature branch:
 ```bash
 git add -A
 git commit -m "design(<epic-slug>): checkpoint"
+```
+
+Release the worktree lock:
+
+```bash
+rm -f .beastmode/.worktree-lock
 ```
 
 Print:

--- a/plugin/skills/plan/SKILL.md
+++ b/plugin/skills/plan/SKILL.md
@@ -18,6 +18,30 @@ Decompose a PRD into independent feature plans. Each feature is a vertical slice
 
 ## Phase 1: Execute
 
+### -1. Acquire Worktree Lock
+
+Before any work, acquire the worktree lock to prevent parallel sessions from modifying the same branch. Design and plan commit directly to the base branch (no worktree), so concurrent sessions would race on `git add -A`.
+
+```bash
+( set -C; echo "$$:plan:$(date -Iseconds)" > .beastmode/.worktree-lock ) 2>/dev/null
+```
+
+If the lock file already exists (command fails), read it and STOP immediately:
+
+```bash
+cat .beastmode/.worktree-lock
+```
+
+Print:
+
+```
+BLOCKED — another beastmode session is active on this branch.
+Lock held by: <contents of lock file>
+Wait for it to finish, or remove .beastmode/.worktree-lock if the session crashed.
+```
+
+STOP. Do not proceed.
+
 ### 0. Check Research Trigger
 
 Research triggers if ANY:
@@ -303,6 +327,12 @@ Commit all work to the feature branch:
 ```bash
 git add -A
 git commit -m "plan(<epic-slug>): checkpoint"
+```
+
+Release the worktree lock:
+
+```bash
+rm -f .beastmode/.worktree-lock
 ```
 
 Print features and their implement commands:


### PR DESCRIPTION
## Summary

- `/design` and `/plan` now acquire an atomic lockfile (`.beastmode/.worktree-lock`) before starting work, preventing parallel sessions from racing on `git add -A`
- Lock is released after the checkpoint commit
- If the lock exists, the session prints diagnostic info and stops

Closes #565

## Changes

**`plugin/skills/design/SKILL.md`**
- Added Step 0: Acquire Worktree Lock to Phase 0 (Pre-Execute)
- Added lock release after checkpoint commit

**`plugin/skills/plan/SKILL.md`**
- Added Step -1: Acquire Worktree Lock to Phase 1 (Execute)
- Added lock release after checkpoint commit

## Why not worktrees?

Design and plan artifacts must land on the base branch so that `/implement` can branch from them. A worktree would add a merge step for zero benefit. The lockfile is a lightweight safety net for the accidental parallel case.

## Mechanism

- `set -C` (noclobber) makes lock acquisition atomic at the shell level
- Lock content includes PID, skill name, and ISO timestamp for diagnostics
- The lock file should be gitignored — the `*.lock` pattern in #559 covers it

## Test plan

- [ ] Run `/design` — verify lock is created at `.beastmode/.worktree-lock`
- [ ] Run `/design` in a second session — verify it blocks with diagnostic message
- [ ] Complete `/design` — verify lock is released after checkpoint
- [ ] Run `/plan` — same acquire/release cycle
- [ ] Manually remove lock after crash — verify next session proceeds